### PR TITLE
:sparkles: Add treafik deployment, rbac, and service

### DIFF
--- a/traefik.deployment.yaml
+++ b/traefik.deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: traefik
-          image: traefik:2.7
+          image: traefik:3.1
           args:
             - "--api.insecure=false"
             - "--api.dashboard=true"

--- a/traefik.deployment.yaml
+++ b/traefik.deployment.yaml
@@ -1,1 +1,31 @@
-#Defines Traefik deployment with 2 replicas.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: traefik
+  namespace: kube-public
+  labels:
+    app: traefik
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: traefik
+  template:
+    metadata:
+      labels:
+        app: traefik
+    spec:
+      containers:
+        - name: traefik
+          image: traefik:2.7
+          args:
+            - "--api.insecure=false"
+            - "--api.dashboard=true"
+            - "--providers.kubernetescrd"
+            - "--entrypoints.web.address=:80"
+          ports:
+            - name: web
+              containerPort: 80
+            - name: admin
+              containerPort: 8080
+      restartPolicy: Always

--- a/traefik.rbac.yaml
+++ b/traefik.rbac.yaml
@@ -1,1 +1,38 @@
-#Grants Traefik access to Kubernetes APIs.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: traefik-rbac
+  namespace: kube-public
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: traefik-rbac
+rules:
+  - apiGroups: [""]
+    resources: ["services", "endpoints", "secrets"]
+    verbs: ["list", "get", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["ingresses"]
+    verbs: ["list", "get", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["ingresses/status"]
+    verbs: ["update"]
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: traefik-rbac
+  namespace: kube-public
+  labels:
+    app: traefik
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: traefik-rbac
+subjects:
+  - kind: ServiceAccount
+    name: traefik-rbac
+    namespace: kube-public

--- a/traefik.service.yaml
+++ b/traefik.service.yaml
@@ -1,1 +1,20 @@
-#Exposes Traefik's HTTP proxy on port 30021 and dashboard on port 30042.
+apiVersion: v1
+kind: Service
+metadata:
+  name: traefik-service
+  namespace: kube-public
+  labels:
+    app: traefik
+spec:
+  type: LoadBalancer
+  selector:
+    app: traefik
+  ports:
+    - name: http-proxy
+      port: 80
+      targetPort: 80
+      nodePort: 30021
+    - name: admin-dashboard
+      port: 8080
+      targetPort: 8080
+      nodePort: 30042


### PR DESCRIPTION
This pull request includes significant updates to the Traefik deployment configuration, including changes to the deployment, RBAC, and service files. These updates aim to better define and secure the Traefik deployment in a Kubernetes environment.

### Traefik Deployment Configuration:

* [`traefik.deployment.yaml`](diffhunk://#diff-3434c30a947366477d73d92617ff2a522dcb49ed9c827a4214ce9f3e3495965cL1-R31): Updated the Traefik deployment to use the `apps/v1` API version and added detailed configuration for the deployment, including metadata, spec, and container details.

### RBAC Configuration:

* [`traefik.rbac.yaml`](diffhunk://#diff-9be285c5a7ceb25f233c7101f8f12d0b6e8546ecf47c67bd375a0b725c5809e0L1-R38): Added a new ServiceAccount, ClusterRole, and ClusterRoleBinding for Traefik to grant it access to necessary Kubernetes APIs.

### Service Configuration:

* [`traefik.service.yaml`](diffhunk://#diff-34dfc448e7b1df841e378107fcd0b27f2d4bb02230a2b5fc70febbfea27d7ab8L1-R20): Defined a new LoadBalancer service for Traefik, exposing the HTTP proxy on port 30021 and the dashboard on port 30042.