### PR TITLE
:placard: Update environment  variable, volume mounts and affinity

### DIFF
--- a/cadvisor.daemonset.yaml
+++ b/cadvisor.daemonset.yaml
@@ -13,14 +13,55 @@ spec:
         app: cadvisor
     spec:
       containers:
-      - name: cadvisor
-        image: gcr.io/cadvisor/cadvisor:latest
-        ports:
-        - containerPort: 8080
-        resources:
-          limits:
-            memory: "128Mi"
+        - name: cadvisor
+          image: gcr.io/cadvisor/cadvisor:latest
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: rootfs
+              mountPath: /rootfs
+              readOnly: true
+            - name: var-run
+              mountPath: /var/run
+              readOnly: true
+            - name: sys
+              mountPath: /sys
+              readOnly: true
+            - name: docker
+              mountPath: /var/lib/docker
+              readOnly: true
+            - name: dev-disk
+              mountPath: /dev/disk
+              readOnly: true
+            - name: kmsg
+              mountPath: /dev/kmsg
+              readOnly: false
+      volumes:
+        - name: rootfs
+          hostPath:
+            path: /
+            type: Directory
+        - name: var-run
+          hostPath:
+            path: /var/run
+            type: Directory
+        - name: sys
+          hostPath:
+            path: /sys
+            type: Directory
+        - name: docker
+          hostPath:
+            path: /var/lib/docker
+            type: Directory
+        - name: dev-disk
+          hostPath:
+            path: /dev/disk
+            type: Directory
+        - name: kmsg
+          hostPath:
+            path: /dev/kmsg
+            type: File
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/master"
+          effect: "NoSchedule"
       restartPolicy: Always

--- a/poll.deployment.yaml
+++ b/poll.deployment.yaml
@@ -21,10 +21,7 @@ spec:
         resources:
           limits:
             memory: "128M"
-        env:
-        - name: REDIS_HOST
-          valueFrom:
-            configMapKeyRef:
-              name: redis-config
-              key: REDIS_HOST
+        envFrom:
+        - configMapRef:
+            name: redis-config
       restartPolicy: Always

--- a/poll.deployment.yaml
+++ b/poll.deployment.yaml
@@ -25,3 +25,13 @@ spec:
         - configMapRef:
             name: redis-config
       restartPolicy: Always
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                      - poll

--- a/result.deployment.yaml
+++ b/result.deployment.yaml
@@ -27,3 +27,13 @@ spec:
         - secretRef:
             name: postgres-secret
       restartPolicy: Always
+      affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - topologyKey: "kubernetes.io/hostname"
+                labelSelector:
+                  matchExpressions:
+                    - key: "app"
+                      operator: In
+                      values:
+                      - result

--- a/worker.deployment.yaml
+++ b/worker.deployment.yaml
@@ -19,35 +19,11 @@ spec:
           resources:
             limits:
               memory: "256M"
-          env:
-            - name: REDIS_HOST
-              valueFrom:
-                configMapKeyRef:
-                  name: redis-config
-                  key: REDIS_HOST
-            - name: POSTGRES_HOST
-              valueFrom:
-                configMapKeyRef:
-                  name: postgres-config
-                  key: POSTGRES_HOST
-            - name: POSTGRES_PORT
-              valueFrom:
-                configMapKeyRef:
-                  name: postgres-config
-                  key: POSTGRES_PORT
-            - name: POSTGRES_DB
-              valueFrom:
-                configMapKeyRef:
-                  name: postgres-config
-                  key: POSTGRES_DB
-            - name: POSTGRES_USER
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: POSTGRES_USER
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: POSTGRES_PASSWORD
+          envFrom:
+            - configMapRef:
+                name: redis-config
+            - configMapRef:
+                name: postgres-config
+            - secretRef:
+                name: postgres-secret
       restartPolicy: Always


### PR DESCRIPTION
This pull request includes several updates to Kubernetes deployment and daemonset configurations to enhance resource management and improve pod scheduling and affinity rules. The most important changes include adding volume mounts to the `cadvisor` daemonset, updating environment variable handling in the `poll` and `worker` deployments, and adding pod anti-affinity rules to the `poll` and `result` deployments.

### Enhancements to resource management:

* [`cadvisor.daemonset.yaml`](diffhunk://#diff-834ac80422f934462d7769943705fceec59eb56b0037ae94a32d28eb055fd9a7L20-R63): Added volume mounts for various system paths (`/rootfs`, `/var/run`, `/sys`, `/var/lib/docker`, `/dev/disk`, `/dev/kmsg`) to the cadvisor container. This helps in better monitoring and resource management.

### Improvements to environment variable handling:

* [`poll.deployment.yaml`](diffhunk://#diff-6087473514dc9138b30f66e1ff00bb830c36c29288238200f54a4d01f3c44bd7L24-R37): Changed environment variable configuration to use `envFrom` with `configMapRef` for `redis-config`. This simplifies the environment variable handling.
* [`worker.deployment.yaml`](diffhunk://#diff-a5af48bb984f620f7e800ebe973c2b2f336e5dc62573eeddd74118a95ea4e21dL22-L52): Updated environment variable configuration to use `envFrom` with `configMapRef` for `redis-config` and `postgres-config`, and `secretRef` for `postgres-secret`. This change simplifies and secures the environment variable management.

### Pod scheduling and affinity improvements:

* [`poll.deployment.yaml`](diffhunk://#diff-6087473514dc9138b30f66e1ff00bb830c36c29288238200f54a4d01f3c44bd7L24-R37): Added pod anti-affinity rules to ensure that pods with the label `app: poll` are not scheduled on the same node, improving fault tolerance.
* [`result.deployment.yaml`](diffhunk://#diff-69738acd97af0c635cbbb1c34f8d8ded9d3c0556c7be409d0ec0f96d4c70d43bR30-R39): Added pod anti-affinity rules to ensure that pods with the label `app: result` are not scheduled on the same node, enhancing reliability.